### PR TITLE
bump urllib3 version to resolve open security vulnerability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ certifi==2018.11.29
 chardet==3.0.4
 idna==2.8
 requests==2.21.0
-urllib3==1.24.1
+urllib3==1.24.2


### PR DESCRIPTION
Github flagged the older urllib3 as having a high severity security vulnerability.
